### PR TITLE
Add PhotosLibrary generated service classes

### DIFF
--- a/src/PhotosLibrary.php
+++ b/src/PhotosLibrary.php
@@ -1,0 +1,295 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service;
+
+use Google\Client;
+
+/**
+ * Service definition for PhotosLibrary (v1).
+ *
+ * <p>
+ * Manage photos, videos, and albums in Google Photos</p>
+ *
+ * <p>
+ * For more information about this service, see the API
+ * <a href="https://developers.google.com/photos/" target="_blank">Documentation</a>
+ * </p>
+ *
+ * @author Google, Inc.
+ */
+class PhotosLibrary extends \Google\Service
+{
+  /** See, upload, and organize items in your Google Photos library. */
+  const PHOTOSLIBRARY =
+      "https://www.googleapis.com/auth/photoslibrary";
+  /** Add to your Google Photos library. */
+  const PHOTOSLIBRARY_APPENDONLY =
+      "https://www.googleapis.com/auth/photoslibrary.appendonly";
+  /** Edit the info in your photos, videos, and albums created within this app, including titles, descriptions, and covers. */
+  const PHOTOSLIBRARY_EDIT_APPCREATEDDATA =
+      "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata";
+  /** View your Google Photos library. */
+  const PHOTOSLIBRARY_READONLY =
+      "https://www.googleapis.com/auth/photoslibrary.readonly";
+  /** Manage photos added by this app. */
+  const PHOTOSLIBRARY_READONLY_APPCREATEDDATA =
+      "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata";
+  /** Manage and add to shared albums on your behalf. */
+  const PHOTOSLIBRARY_SHARING =
+      "https://www.googleapis.com/auth/photoslibrary.sharing";
+
+  public $albums;
+  public $mediaItems;
+  public $sharedAlbums;
+
+  /**
+   * Constructs the internal representation of the PhotosLibrary service.
+   *
+   * @param Client|array $clientOrConfig The client used to deliver requests, or a
+   *                                     config array to pass to a new Client instance.
+   * @param string $rootUrl The root URL used for requests to the service.
+   */
+  public function __construct($clientOrConfig = [], $rootUrl = null)
+  {
+    parent::__construct($clientOrConfig);
+    $this->rootUrl = $rootUrl ?: 'https://photoslibrary.googleapis.com/';
+    $this->servicePath = '';
+    $this->batchPath = 'batch';
+    $this->version = 'v1';
+    $this->serviceName = 'photoslibrary';
+
+    $this->albums = new PhotosLibrary\Resource\Albums(
+        $this,
+        $this->serviceName,
+        'albums',
+        [
+          'methods' => [
+            'addEnrichment' => [
+              'path' => 'v1/albums/{+albumId}:addEnrichment',
+              'httpMethod' => 'POST',
+              'parameters' => [
+                'albumId' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+              ],
+            ],'batchAddMediaItems' => [
+              'path' => 'v1/albums/{+albumId}:batchAddMediaItems',
+              'httpMethod' => 'POST',
+              'parameters' => [
+                'albumId' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+              ],
+            ],'batchRemoveMediaItems' => [
+              'path' => 'v1/albums/{+albumId}:batchRemoveMediaItems',
+              'httpMethod' => 'POST',
+              'parameters' => [
+                'albumId' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+              ],
+            ],'create' => [
+              'path' => 'v1/albums',
+              'httpMethod' => 'POST',
+              'parameters' => [],
+            ],'get' => [
+              'path' => 'v1/albums/{+albumId}',
+              'httpMethod' => 'GET',
+              'parameters' => [
+                'albumId' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+              ],
+            ],'list' => [
+              'path' => 'v1/albums',
+              'httpMethod' => 'GET',
+              'parameters' => [
+                'excludeNonAppCreatedData' => [
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ],
+                'pageSize' => [
+                  'location' => 'query',
+                  'type' => 'integer',
+                ],
+                'pageToken' => [
+                  'location' => 'query',
+                  'type' => 'string',
+                ],
+              ],
+            ],'patch' => [
+              'path' => 'v1/albums/{+id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => [
+                'id' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+                'updateMask' => [
+                  'location' => 'query',
+                  'type' => 'string',
+                ],
+              ],
+            ],'share' => [
+              'path' => 'v1/albums/{+albumId}:share',
+              'httpMethod' => 'POST',
+              'parameters' => [
+                'albumId' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+              ],
+            ],'unshare' => [
+              'path' => 'v1/albums/{+albumId}:unshare',
+              'httpMethod' => 'POST',
+              'parameters' => [
+                'albumId' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+              ],
+            ],
+          ]
+        ]
+    );
+    $this->mediaItems = new PhotosLibrary\Resource\MediaItems(
+        $this,
+        $this->serviceName,
+        'mediaItems',
+        [
+          'methods' => [
+            'batchCreate' => [
+              'path' => 'v1/mediaItems:batchCreate',
+              'httpMethod' => 'POST',
+              'parameters' => [],
+            ],'batchGet' => [
+              'path' => 'v1/mediaItems:batchGet',
+              'httpMethod' => 'GET',
+              'parameters' => [
+                'mediaItemIds' => [
+                  'location' => 'query',
+                  'type' => 'string',
+                  'repeated' => true,
+                ],
+              ],
+            ],'get' => [
+              'path' => 'v1/mediaItems/{+mediaItemId}',
+              'httpMethod' => 'GET',
+              'parameters' => [
+                'mediaItemId' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+              ],
+            ],'list' => [
+              'path' => 'v1/mediaItems',
+              'httpMethod' => 'GET',
+              'parameters' => [
+                'pageSize' => [
+                  'location' => 'query',
+                  'type' => 'integer',
+                ],
+                'pageToken' => [
+                  'location' => 'query',
+                  'type' => 'string',
+                ],
+              ],
+            ],'patch' => [
+              'path' => 'v1/mediaItems/{+id}',
+              'httpMethod' => 'PATCH',
+              'parameters' => [
+                'id' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+                'updateMask' => [
+                  'location' => 'query',
+                  'type' => 'string',
+                ],
+              ],
+            ],'search' => [
+              'path' => 'v1/mediaItems:search',
+              'httpMethod' => 'POST',
+              'parameters' => [],
+            ],
+          ]
+        ]
+    );
+    $this->sharedAlbums = new PhotosLibrary\Resource\SharedAlbums(
+        $this,
+        $this->serviceName,
+        'sharedAlbums',
+        [
+          'methods' => [
+            'get' => [
+              'path' => 'v1/sharedAlbums/{+shareToken}',
+              'httpMethod' => 'GET',
+              'parameters' => [
+                'shareToken' => [
+                  'location' => 'path',
+                  'type' => 'string',
+                  'required' => true,
+                ],
+              ],
+            ],'join' => [
+              'path' => 'v1/sharedAlbums:join',
+              'httpMethod' => 'POST',
+              'parameters' => [],
+            ],'leave' => [
+              'path' => 'v1/sharedAlbums:leave',
+              'httpMethod' => 'POST',
+              'parameters' => [],
+            ],'list' => [
+              'path' => 'v1/sharedAlbums',
+              'httpMethod' => 'GET',
+              'parameters' => [
+                'excludeNonAppCreatedData' => [
+                  'location' => 'query',
+                  'type' => 'boolean',
+                ],
+                'pageSize' => [
+                  'location' => 'query',
+                  'type' => 'integer',
+                ],
+                'pageToken' => [
+                  'location' => 'query',
+                  'type' => 'string',
+                ],
+              ],
+            ],
+          ]
+        ]
+    );
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(PhotosLibrary::class, 'Google_Service_PhotosLibrary');

--- a/src/PhotosLibrary/AddEnrichmentToAlbumRequest.php
+++ b/src/PhotosLibrary/AddEnrichmentToAlbumRequest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class AddEnrichmentToAlbumRequest extends \Google\Model
+{
+  protected $albumPositionType = AlbumPosition::class;
+  protected $albumPositionDataType = '';
+  protected $newEnrichmentItemType = NewEnrichmentItem::class;
+  protected $newEnrichmentItemDataType = '';
+
+  /**
+   * @param AlbumPosition
+   */
+  public function setAlbumPosition(AlbumPosition $albumPosition)
+  {
+    $this->albumPosition = $albumPosition;
+  }
+  /**
+   * @return AlbumPosition
+   */
+  public function getAlbumPosition()
+  {
+    return $this->albumPosition;
+  }
+  /**
+   * @param NewEnrichmentItem
+   */
+  public function setNewEnrichmentItem(NewEnrichmentItem $newEnrichmentItem)
+  {
+    $this->newEnrichmentItem = $newEnrichmentItem;
+  }
+  /**
+   * @return NewEnrichmentItem
+   */
+  public function getNewEnrichmentItem()
+  {
+    return $this->newEnrichmentItem;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(AddEnrichmentToAlbumRequest::class, 'Google_Service_PhotosLibrary_AddEnrichmentToAlbumRequest');

--- a/src/PhotosLibrary/AddEnrichmentToAlbumResponse.php
+++ b/src/PhotosLibrary/AddEnrichmentToAlbumResponse.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class AddEnrichmentToAlbumResponse extends \Google\Model
+{
+  protected $enrichmentItemType = EnrichmentItem::class;
+  protected $enrichmentItemDataType = '';
+
+  /**
+   * @param EnrichmentItem
+   */
+  public function setEnrichmentItem(EnrichmentItem $enrichmentItem)
+  {
+    $this->enrichmentItem = $enrichmentItem;
+  }
+  /**
+   * @return EnrichmentItem
+   */
+  public function getEnrichmentItem()
+  {
+    return $this->enrichmentItem;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(AddEnrichmentToAlbumResponse::class, 'Google_Service_PhotosLibrary_AddEnrichmentToAlbumResponse');

--- a/src/PhotosLibrary/Album.php
+++ b/src/PhotosLibrary/Album.php
@@ -1,0 +1,168 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class Album extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $coverPhotoBaseUrl;
+  /**
+   * @var string
+   */
+  public $coverPhotoMediaItemId;
+  /**
+   * @var string
+   */
+  public $id;
+  /**
+   * @var bool
+   */
+  public $isWriteable;
+  /**
+   * @var string
+   */
+  public $mediaItemsCount;
+  /**
+   * @var string
+   */
+  public $productUrl;
+  protected $shareInfoType = ShareInfo::class;
+  protected $shareInfoDataType = '';
+  /**
+   * @var string
+   */
+  public $title;
+
+  /**
+   * @param string
+   */
+  public function setCoverPhotoBaseUrl($coverPhotoBaseUrl)
+  {
+    $this->coverPhotoBaseUrl = $coverPhotoBaseUrl;
+  }
+  /**
+   * @return string
+   */
+  public function getCoverPhotoBaseUrl()
+  {
+    return $this->coverPhotoBaseUrl;
+  }
+  /**
+   * @param string
+   */
+  public function setCoverPhotoMediaItemId($coverPhotoMediaItemId)
+  {
+    $this->coverPhotoMediaItemId = $coverPhotoMediaItemId;
+  }
+  /**
+   * @return string
+   */
+  public function getCoverPhotoMediaItemId()
+  {
+    return $this->coverPhotoMediaItemId;
+  }
+  /**
+   * @param string
+   */
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  /**
+   * @return string
+   */
+  public function getId()
+  {
+    return $this->id;
+  }
+  /**
+   * @param bool
+   */
+  public function setIsWriteable($isWriteable)
+  {
+    $this->isWriteable = $isWriteable;
+  }
+  /**
+   * @return bool
+   */
+  public function getIsWriteable()
+  {
+    return $this->isWriteable;
+  }
+  /**
+   * @param string
+   */
+  public function setMediaItemsCount($mediaItemsCount)
+  {
+    $this->mediaItemsCount = $mediaItemsCount;
+  }
+  /**
+   * @return string
+   */
+  public function getMediaItemsCount()
+  {
+    return $this->mediaItemsCount;
+  }
+  /**
+   * @param string
+   */
+  public function setProductUrl($productUrl)
+  {
+    $this->productUrl = $productUrl;
+  }
+  /**
+   * @return string
+   */
+  public function getProductUrl()
+  {
+    return $this->productUrl;
+  }
+  /**
+   * @param ShareInfo
+   */
+  public function setShareInfo(ShareInfo $shareInfo)
+  {
+    $this->shareInfo = $shareInfo;
+  }
+  /**
+   * @return ShareInfo
+   */
+  public function getShareInfo()
+  {
+    return $this->shareInfo;
+  }
+  /**
+   * @param string
+   */
+  public function setTitle($title)
+  {
+    $this->title = $title;
+  }
+  /**
+   * @return string
+   */
+  public function getTitle()
+  {
+    return $this->title;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Album::class, 'Google_Service_PhotosLibrary_Album');

--- a/src/PhotosLibrary/AlbumPosition.php
+++ b/src/PhotosLibrary/AlbumPosition.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class AlbumPosition extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $position;
+  /**
+   * @var string
+   */
+  public $relativeEnrichmentItemId;
+  /**
+   * @var string
+   */
+  public $relativeMediaItemId;
+
+  /**
+   * @param string
+   */
+  public function setPosition($position)
+  {
+    $this->position = $position;
+  }
+  /**
+   * @return string
+   */
+  public function getPosition()
+  {
+    return $this->position;
+  }
+  /**
+   * @param string
+   */
+  public function setRelativeEnrichmentItemId($relativeEnrichmentItemId)
+  {
+    $this->relativeEnrichmentItemId = $relativeEnrichmentItemId;
+  }
+  /**
+   * @return string
+   */
+  public function getRelativeEnrichmentItemId()
+  {
+    return $this->relativeEnrichmentItemId;
+  }
+  /**
+   * @param string
+   */
+  public function setRelativeMediaItemId($relativeMediaItemId)
+  {
+    $this->relativeMediaItemId = $relativeMediaItemId;
+  }
+  /**
+   * @return string
+   */
+  public function getRelativeMediaItemId()
+  {
+    return $this->relativeMediaItemId;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(AlbumPosition::class, 'Google_Service_PhotosLibrary_AlbumPosition');

--- a/src/PhotosLibrary/BatchAddMediaItemsToAlbumRequest.php
+++ b/src/PhotosLibrary/BatchAddMediaItemsToAlbumRequest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class BatchAddMediaItemsToAlbumRequest extends \Google\Collection
+{
+  protected $collection_key = 'mediaItemIds';
+  /**
+   * @var string[]
+   */
+  public $mediaItemIds;
+
+  /**
+   * @param string[]
+   */
+  public function setMediaItemIds($mediaItemIds)
+  {
+    $this->mediaItemIds = $mediaItemIds;
+  }
+  /**
+   * @return string[]
+   */
+  public function getMediaItemIds()
+  {
+    return $this->mediaItemIds;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(BatchAddMediaItemsToAlbumRequest::class, 'Google_Service_PhotosLibrary_BatchAddMediaItemsToAlbumRequest');

--- a/src/PhotosLibrary/BatchAddMediaItemsToAlbumResponse.php
+++ b/src/PhotosLibrary/BatchAddMediaItemsToAlbumResponse.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class BatchAddMediaItemsToAlbumResponse extends \Google\Model
+{
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(BatchAddMediaItemsToAlbumResponse::class, 'Google_Service_PhotosLibrary_BatchAddMediaItemsToAlbumResponse');

--- a/src/PhotosLibrary/BatchCreateMediaItemsRequest.php
+++ b/src/PhotosLibrary/BatchCreateMediaItemsRequest.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class BatchCreateMediaItemsRequest extends \Google\Collection
+{
+  protected $collection_key = 'newMediaItems';
+  /**
+   * @var string
+   */
+  public $albumId;
+  protected $albumPositionType = AlbumPosition::class;
+  protected $albumPositionDataType = '';
+  protected $newMediaItemsType = NewMediaItem::class;
+  protected $newMediaItemsDataType = 'array';
+
+  /**
+   * @param string
+   */
+  public function setAlbumId($albumId)
+  {
+    $this->albumId = $albumId;
+  }
+  /**
+   * @return string
+   */
+  public function getAlbumId()
+  {
+    return $this->albumId;
+  }
+  /**
+   * @param AlbumPosition
+   */
+  public function setAlbumPosition(AlbumPosition $albumPosition)
+  {
+    $this->albumPosition = $albumPosition;
+  }
+  /**
+   * @return AlbumPosition
+   */
+  public function getAlbumPosition()
+  {
+    return $this->albumPosition;
+  }
+  /**
+   * @param NewMediaItem[]
+   */
+  public function setNewMediaItems($newMediaItems)
+  {
+    $this->newMediaItems = $newMediaItems;
+  }
+  /**
+   * @return NewMediaItem[]
+   */
+  public function getNewMediaItems()
+  {
+    return $this->newMediaItems;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(BatchCreateMediaItemsRequest::class, 'Google_Service_PhotosLibrary_BatchCreateMediaItemsRequest');

--- a/src/PhotosLibrary/BatchCreateMediaItemsResponse.php
+++ b/src/PhotosLibrary/BatchCreateMediaItemsResponse.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class BatchCreateMediaItemsResponse extends \Google\Collection
+{
+  protected $collection_key = 'newMediaItemResults';
+  protected $newMediaItemResultsType = NewMediaItemResult::class;
+  protected $newMediaItemResultsDataType = 'array';
+
+  /**
+   * @param NewMediaItemResult[]
+   */
+  public function setNewMediaItemResults($newMediaItemResults)
+  {
+    $this->newMediaItemResults = $newMediaItemResults;
+  }
+  /**
+   * @return NewMediaItemResult[]
+   */
+  public function getNewMediaItemResults()
+  {
+    return $this->newMediaItemResults;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(BatchCreateMediaItemsResponse::class, 'Google_Service_PhotosLibrary_BatchCreateMediaItemsResponse');

--- a/src/PhotosLibrary/BatchGetMediaItemsResponse.php
+++ b/src/PhotosLibrary/BatchGetMediaItemsResponse.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class BatchGetMediaItemsResponse extends \Google\Collection
+{
+  protected $collection_key = 'mediaItemResults';
+  protected $mediaItemResultsType = MediaItemResult::class;
+  protected $mediaItemResultsDataType = 'array';
+
+  /**
+   * @param MediaItemResult[]
+   */
+  public function setMediaItemResults($mediaItemResults)
+  {
+    $this->mediaItemResults = $mediaItemResults;
+  }
+  /**
+   * @return MediaItemResult[]
+   */
+  public function getMediaItemResults()
+  {
+    return $this->mediaItemResults;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(BatchGetMediaItemsResponse::class, 'Google_Service_PhotosLibrary_BatchGetMediaItemsResponse');

--- a/src/PhotosLibrary/BatchRemoveMediaItemsFromAlbumRequest.php
+++ b/src/PhotosLibrary/BatchRemoveMediaItemsFromAlbumRequest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class BatchRemoveMediaItemsFromAlbumRequest extends \Google\Collection
+{
+  protected $collection_key = 'mediaItemIds';
+  /**
+   * @var string[]
+   */
+  public $mediaItemIds;
+
+  /**
+   * @param string[]
+   */
+  public function setMediaItemIds($mediaItemIds)
+  {
+    $this->mediaItemIds = $mediaItemIds;
+  }
+  /**
+   * @return string[]
+   */
+  public function getMediaItemIds()
+  {
+    return $this->mediaItemIds;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(BatchRemoveMediaItemsFromAlbumRequest::class, 'Google_Service_PhotosLibrary_BatchRemoveMediaItemsFromAlbumRequest');

--- a/src/PhotosLibrary/BatchRemoveMediaItemsFromAlbumResponse.php
+++ b/src/PhotosLibrary/BatchRemoveMediaItemsFromAlbumResponse.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class BatchRemoveMediaItemsFromAlbumResponse extends \Google\Model
+{
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(BatchRemoveMediaItemsFromAlbumResponse::class, 'Google_Service_PhotosLibrary_BatchRemoveMediaItemsFromAlbumResponse');

--- a/src/PhotosLibrary/ContentFilter.php
+++ b/src/PhotosLibrary/ContentFilter.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class ContentFilter extends \Google\Collection
+{
+  protected $collection_key = 'includedContentCategories';
+  /**
+   * @var string[]
+   */
+  public $excludedContentCategories;
+  /**
+   * @var string[]
+   */
+  public $includedContentCategories;
+
+  /**
+   * @param string[]
+   */
+  public function setExcludedContentCategories($excludedContentCategories)
+  {
+    $this->excludedContentCategories = $excludedContentCategories;
+  }
+  /**
+   * @return string[]
+   */
+  public function getExcludedContentCategories()
+  {
+    return $this->excludedContentCategories;
+  }
+  /**
+   * @param string[]
+   */
+  public function setIncludedContentCategories($includedContentCategories)
+  {
+    $this->includedContentCategories = $includedContentCategories;
+  }
+  /**
+   * @return string[]
+   */
+  public function getIncludedContentCategories()
+  {
+    return $this->includedContentCategories;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ContentFilter::class, 'Google_Service_PhotosLibrary_ContentFilter');

--- a/src/PhotosLibrary/ContributorInfo.php
+++ b/src/PhotosLibrary/ContributorInfo.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class ContributorInfo extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $displayName;
+  /**
+   * @var string
+   */
+  public $profilePictureBaseUrl;
+
+  /**
+   * @param string
+   */
+  public function setDisplayName($displayName)
+  {
+    $this->displayName = $displayName;
+  }
+  /**
+   * @return string
+   */
+  public function getDisplayName()
+  {
+    return $this->displayName;
+  }
+  /**
+   * @param string
+   */
+  public function setProfilePictureBaseUrl($profilePictureBaseUrl)
+  {
+    $this->profilePictureBaseUrl = $profilePictureBaseUrl;
+  }
+  /**
+   * @return string
+   */
+  public function getProfilePictureBaseUrl()
+  {
+    return $this->profilePictureBaseUrl;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ContributorInfo::class, 'Google_Service_PhotosLibrary_ContributorInfo');

--- a/src/PhotosLibrary/CreateAlbumRequest.php
+++ b/src/PhotosLibrary/CreateAlbumRequest.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class CreateAlbumRequest extends \Google\Model
+{
+  protected $albumType = Album::class;
+  protected $albumDataType = '';
+
+  /**
+   * @param Album
+   */
+  public function setAlbum(Album $album)
+  {
+    $this->album = $album;
+  }
+  /**
+   * @return Album
+   */
+  public function getAlbum()
+  {
+    return $this->album;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(CreateAlbumRequest::class, 'Google_Service_PhotosLibrary_CreateAlbumRequest');

--- a/src/PhotosLibrary/Date.php
+++ b/src/PhotosLibrary/Date.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class Date extends \Google\Model
+{
+  /**
+   * @var int
+   */
+  public $day;
+  /**
+   * @var int
+   */
+  public $month;
+  /**
+   * @var int
+   */
+  public $year;
+
+  /**
+   * @param int
+   */
+  public function setDay($day)
+  {
+    $this->day = $day;
+  }
+  /**
+   * @return int
+   */
+  public function getDay()
+  {
+    return $this->day;
+  }
+  /**
+   * @param int
+   */
+  public function setMonth($month)
+  {
+    $this->month = $month;
+  }
+  /**
+   * @return int
+   */
+  public function getMonth()
+  {
+    return $this->month;
+  }
+  /**
+   * @param int
+   */
+  public function setYear($year)
+  {
+    $this->year = $year;
+  }
+  /**
+   * @return int
+   */
+  public function getYear()
+  {
+    return $this->year;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Date::class, 'Google_Service_PhotosLibrary_Date');

--- a/src/PhotosLibrary/DateFilter.php
+++ b/src/PhotosLibrary/DateFilter.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class DateFilter extends \Google\Collection
+{
+  protected $collection_key = 'ranges';
+  protected $datesType = Date::class;
+  protected $datesDataType = 'array';
+  protected $rangesType = DateRange::class;
+  protected $rangesDataType = 'array';
+
+  /**
+   * @param Date[]
+   */
+  public function setDates($dates)
+  {
+    $this->dates = $dates;
+  }
+  /**
+   * @return Date[]
+   */
+  public function getDates()
+  {
+    return $this->dates;
+  }
+  /**
+   * @param DateRange[]
+   */
+  public function setRanges($ranges)
+  {
+    $this->ranges = $ranges;
+  }
+  /**
+   * @return DateRange[]
+   */
+  public function getRanges()
+  {
+    return $this->ranges;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(DateFilter::class, 'Google_Service_PhotosLibrary_DateFilter');

--- a/src/PhotosLibrary/DateRange.php
+++ b/src/PhotosLibrary/DateRange.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class DateRange extends \Google\Model
+{
+  protected $endDateType = Date::class;
+  protected $endDateDataType = '';
+  protected $startDateType = Date::class;
+  protected $startDateDataType = '';
+
+  /**
+   * @param Date
+   */
+  public function setEndDate(Date $endDate)
+  {
+    $this->endDate = $endDate;
+  }
+  /**
+   * @return Date
+   */
+  public function getEndDate()
+  {
+    return $this->endDate;
+  }
+  /**
+   * @param Date
+   */
+  public function setStartDate(Date $startDate)
+  {
+    $this->startDate = $startDate;
+  }
+  /**
+   * @return Date
+   */
+  public function getStartDate()
+  {
+    return $this->startDate;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(DateRange::class, 'Google_Service_PhotosLibrary_DateRange');

--- a/src/PhotosLibrary/EnrichmentItem.php
+++ b/src/PhotosLibrary/EnrichmentItem.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class EnrichmentItem extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $id;
+
+  /**
+   * @param string
+   */
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  /**
+   * @return string
+   */
+  public function getId()
+  {
+    return $this->id;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(EnrichmentItem::class, 'Google_Service_PhotosLibrary_EnrichmentItem');

--- a/src/PhotosLibrary/FeatureFilter.php
+++ b/src/PhotosLibrary/FeatureFilter.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class FeatureFilter extends \Google\Collection
+{
+  protected $collection_key = 'includedFeatures';
+  /**
+   * @var string[]
+   */
+  public $includedFeatures;
+
+  /**
+   * @param string[]
+   */
+  public function setIncludedFeatures($includedFeatures)
+  {
+    $this->includedFeatures = $includedFeatures;
+  }
+  /**
+   * @return string[]
+   */
+  public function getIncludedFeatures()
+  {
+    return $this->includedFeatures;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(FeatureFilter::class, 'Google_Service_PhotosLibrary_FeatureFilter');

--- a/src/PhotosLibrary/Filters.php
+++ b/src/PhotosLibrary/Filters.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class Filters extends \Google\Model
+{
+  protected $contentFilterType = ContentFilter::class;
+  protected $contentFilterDataType = '';
+  protected $dateFilterType = DateFilter::class;
+  protected $dateFilterDataType = '';
+  /**
+   * @var bool
+   */
+  public $excludeNonAppCreatedData;
+  protected $featureFilterType = FeatureFilter::class;
+  protected $featureFilterDataType = '';
+  /**
+   * @var bool
+   */
+  public $includeArchivedMedia;
+  protected $mediaTypeFilterType = MediaTypeFilter::class;
+  protected $mediaTypeFilterDataType = '';
+
+  /**
+   * @param ContentFilter
+   */
+  public function setContentFilter(ContentFilter $contentFilter)
+  {
+    $this->contentFilter = $contentFilter;
+  }
+  /**
+   * @return ContentFilter
+   */
+  public function getContentFilter()
+  {
+    return $this->contentFilter;
+  }
+  /**
+   * @param DateFilter
+   */
+  public function setDateFilter(DateFilter $dateFilter)
+  {
+    $this->dateFilter = $dateFilter;
+  }
+  /**
+   * @return DateFilter
+   */
+  public function getDateFilter()
+  {
+    return $this->dateFilter;
+  }
+  /**
+   * @param bool
+   */
+  public function setExcludeNonAppCreatedData($excludeNonAppCreatedData)
+  {
+    $this->excludeNonAppCreatedData = $excludeNonAppCreatedData;
+  }
+  /**
+   * @return bool
+   */
+  public function getExcludeNonAppCreatedData()
+  {
+    return $this->excludeNonAppCreatedData;
+  }
+  /**
+   * @param FeatureFilter
+   */
+  public function setFeatureFilter(FeatureFilter $featureFilter)
+  {
+    $this->featureFilter = $featureFilter;
+  }
+  /**
+   * @return FeatureFilter
+   */
+  public function getFeatureFilter()
+  {
+    return $this->featureFilter;
+  }
+  /**
+   * @param bool
+   */
+  public function setIncludeArchivedMedia($includeArchivedMedia)
+  {
+    $this->includeArchivedMedia = $includeArchivedMedia;
+  }
+  /**
+   * @return bool
+   */
+  public function getIncludeArchivedMedia()
+  {
+    return $this->includeArchivedMedia;
+  }
+  /**
+   * @param MediaTypeFilter
+   */
+  public function setMediaTypeFilter(MediaTypeFilter $mediaTypeFilter)
+  {
+    $this->mediaTypeFilter = $mediaTypeFilter;
+  }
+  /**
+   * @return MediaTypeFilter
+   */
+  public function getMediaTypeFilter()
+  {
+    return $this->mediaTypeFilter;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Filters::class, 'Google_Service_PhotosLibrary_Filters');

--- a/src/PhotosLibrary/JoinSharedAlbumRequest.php
+++ b/src/PhotosLibrary/JoinSharedAlbumRequest.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class JoinSharedAlbumRequest extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $shareToken;
+
+  /**
+   * @param string
+   */
+  public function setShareToken($shareToken)
+  {
+    $this->shareToken = $shareToken;
+  }
+  /**
+   * @return string
+   */
+  public function getShareToken()
+  {
+    return $this->shareToken;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(JoinSharedAlbumRequest::class, 'Google_Service_PhotosLibrary_JoinSharedAlbumRequest');

--- a/src/PhotosLibrary/JoinSharedAlbumResponse.php
+++ b/src/PhotosLibrary/JoinSharedAlbumResponse.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class JoinSharedAlbumResponse extends \Google\Model
+{
+  protected $albumType = Album::class;
+  protected $albumDataType = '';
+
+  /**
+   * @param Album
+   */
+  public function setAlbum(Album $album)
+  {
+    $this->album = $album;
+  }
+  /**
+   * @return Album
+   */
+  public function getAlbum()
+  {
+    return $this->album;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(JoinSharedAlbumResponse::class, 'Google_Service_PhotosLibrary_JoinSharedAlbumResponse');

--- a/src/PhotosLibrary/LatLng.php
+++ b/src/PhotosLibrary/LatLng.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class LatLng extends \Google\Model
+{
+  public $latitude;
+  public $longitude;
+
+  public function setLatitude($latitude)
+  {
+    $this->latitude = $latitude;
+  }
+  public function getLatitude()
+  {
+    return $this->latitude;
+  }
+  public function setLongitude($longitude)
+  {
+    $this->longitude = $longitude;
+  }
+  public function getLongitude()
+  {
+    return $this->longitude;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(LatLng::class, 'Google_Service_PhotosLibrary_LatLng');

--- a/src/PhotosLibrary/LeaveSharedAlbumRequest.php
+++ b/src/PhotosLibrary/LeaveSharedAlbumRequest.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class LeaveSharedAlbumRequest extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $shareToken;
+
+  /**
+   * @param string
+   */
+  public function setShareToken($shareToken)
+  {
+    $this->shareToken = $shareToken;
+  }
+  /**
+   * @return string
+   */
+  public function getShareToken()
+  {
+    return $this->shareToken;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(LeaveSharedAlbumRequest::class, 'Google_Service_PhotosLibrary_LeaveSharedAlbumRequest');

--- a/src/PhotosLibrary/LeaveSharedAlbumResponse.php
+++ b/src/PhotosLibrary/LeaveSharedAlbumResponse.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class LeaveSharedAlbumResponse extends \Google\Model
+{
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(LeaveSharedAlbumResponse::class, 'Google_Service_PhotosLibrary_LeaveSharedAlbumResponse');

--- a/src/PhotosLibrary/ListAlbumsResponse.php
+++ b/src/PhotosLibrary/ListAlbumsResponse.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class ListAlbumsResponse extends \Google\Collection
+{
+  protected $collection_key = 'albums';
+  protected $albumsType = Album::class;
+  protected $albumsDataType = 'array';
+  /**
+   * @var string
+   */
+  public $nextPageToken;
+
+  /**
+   * @param Album[]
+   */
+  public function setAlbums($albums)
+  {
+    $this->albums = $albums;
+  }
+  /**
+   * @return Album[]
+   */
+  public function getAlbums()
+  {
+    return $this->albums;
+  }
+  /**
+   * @param string
+   */
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  /**
+   * @return string
+   */
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ListAlbumsResponse::class, 'Google_Service_PhotosLibrary_ListAlbumsResponse');

--- a/src/PhotosLibrary/ListMediaItemsResponse.php
+++ b/src/PhotosLibrary/ListMediaItemsResponse.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class ListMediaItemsResponse extends \Google\Collection
+{
+  protected $collection_key = 'mediaItems';
+  protected $mediaItemsType = MediaItem::class;
+  protected $mediaItemsDataType = 'array';
+  /**
+   * @var string
+   */
+  public $nextPageToken;
+
+  /**
+   * @param MediaItem[]
+   */
+  public function setMediaItems($mediaItems)
+  {
+    $this->mediaItems = $mediaItems;
+  }
+  /**
+   * @return MediaItem[]
+   */
+  public function getMediaItems()
+  {
+    return $this->mediaItems;
+  }
+  /**
+   * @param string
+   */
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  /**
+   * @return string
+   */
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ListMediaItemsResponse::class, 'Google_Service_PhotosLibrary_ListMediaItemsResponse');

--- a/src/PhotosLibrary/ListSharedAlbumsResponse.php
+++ b/src/PhotosLibrary/ListSharedAlbumsResponse.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class ListSharedAlbumsResponse extends \Google\Collection
+{
+  protected $collection_key = 'sharedAlbums';
+  /**
+   * @var string
+   */
+  public $nextPageToken;
+  protected $sharedAlbumsType = Album::class;
+  protected $sharedAlbumsDataType = 'array';
+
+  /**
+   * @param string
+   */
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  /**
+   * @return string
+   */
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+  /**
+   * @param Album[]
+   */
+  public function setSharedAlbums($sharedAlbums)
+  {
+    $this->sharedAlbums = $sharedAlbums;
+  }
+  /**
+   * @return Album[]
+   */
+  public function getSharedAlbums()
+  {
+    return $this->sharedAlbums;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ListSharedAlbumsResponse::class, 'Google_Service_PhotosLibrary_ListSharedAlbumsResponse');

--- a/src/PhotosLibrary/Location.php
+++ b/src/PhotosLibrary/Location.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class Location extends \Google\Model
+{
+  protected $latlngType = LatLng::class;
+  protected $latlngDataType = '';
+  /**
+   * @var string
+   */
+  public $locationName;
+
+  /**
+   * @param LatLng
+   */
+  public function setLatlng(LatLng $latlng)
+  {
+    $this->latlng = $latlng;
+  }
+  /**
+   * @return LatLng
+   */
+  public function getLatlng()
+  {
+    return $this->latlng;
+  }
+  /**
+   * @param string
+   */
+  public function setLocationName($locationName)
+  {
+    $this->locationName = $locationName;
+  }
+  /**
+   * @return string
+   */
+  public function getLocationName()
+  {
+    return $this->locationName;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Location::class, 'Google_Service_PhotosLibrary_Location');

--- a/src/PhotosLibrary/LocationEnrichment.php
+++ b/src/PhotosLibrary/LocationEnrichment.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class LocationEnrichment extends \Google\Model
+{
+  protected $locationType = Location::class;
+  protected $locationDataType = '';
+
+  /**
+   * @param Location
+   */
+  public function setLocation(Location $location)
+  {
+    $this->location = $location;
+  }
+  /**
+   * @return Location
+   */
+  public function getLocation()
+  {
+    return $this->location;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(LocationEnrichment::class, 'Google_Service_PhotosLibrary_LocationEnrichment');

--- a/src/PhotosLibrary/MapEnrichment.php
+++ b/src/PhotosLibrary/MapEnrichment.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class MapEnrichment extends \Google\Model
+{
+  protected $destinationType = Location::class;
+  protected $destinationDataType = '';
+  protected $originType = Location::class;
+  protected $originDataType = '';
+
+  /**
+   * @param Location
+   */
+  public function setDestination(Location $destination)
+  {
+    $this->destination = $destination;
+  }
+  /**
+   * @return Location
+   */
+  public function getDestination()
+  {
+    return $this->destination;
+  }
+  /**
+   * @param Location
+   */
+  public function setOrigin(Location $origin)
+  {
+    $this->origin = $origin;
+  }
+  /**
+   * @return Location
+   */
+  public function getOrigin()
+  {
+    return $this->origin;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(MapEnrichment::class, 'Google_Service_PhotosLibrary_MapEnrichment');

--- a/src/PhotosLibrary/MediaItem.php
+++ b/src/PhotosLibrary/MediaItem.php
@@ -1,0 +1,166 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class MediaItem extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $baseUrl;
+  protected $contributorInfoType = ContributorInfo::class;
+  protected $contributorInfoDataType = '';
+  /**
+   * @var string
+   */
+  public $description;
+  /**
+   * @var string
+   */
+  public $filename;
+  /**
+   * @var string
+   */
+  public $id;
+  protected $mediaMetadataType = MediaMetadata::class;
+  protected $mediaMetadataDataType = '';
+  /**
+   * @var string
+   */
+  public $mimeType;
+  /**
+   * @var string
+   */
+  public $productUrl;
+
+  /**
+   * @param string
+   */
+  public function setBaseUrl($baseUrl)
+  {
+    $this->baseUrl = $baseUrl;
+  }
+  /**
+   * @return string
+   */
+  public function getBaseUrl()
+  {
+    return $this->baseUrl;
+  }
+  /**
+   * @param ContributorInfo
+   */
+  public function setContributorInfo(ContributorInfo $contributorInfo)
+  {
+    $this->contributorInfo = $contributorInfo;
+  }
+  /**
+   * @return ContributorInfo
+   */
+  public function getContributorInfo()
+  {
+    return $this->contributorInfo;
+  }
+  /**
+   * @param string
+   */
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  /**
+   * @return string
+   */
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  /**
+   * @param string
+   */
+  public function setFilename($filename)
+  {
+    $this->filename = $filename;
+  }
+  /**
+   * @return string
+   */
+  public function getFilename()
+  {
+    return $this->filename;
+  }
+  /**
+   * @param string
+   */
+  public function setId($id)
+  {
+    $this->id = $id;
+  }
+  /**
+   * @return string
+   */
+  public function getId()
+  {
+    return $this->id;
+  }
+  /**
+   * @param MediaMetadata
+   */
+  public function setMediaMetadata(MediaMetadata $mediaMetadata)
+  {
+    $this->mediaMetadata = $mediaMetadata;
+  }
+  /**
+   * @return MediaMetadata
+   */
+  public function getMediaMetadata()
+  {
+    return $this->mediaMetadata;
+  }
+  /**
+   * @param string
+   */
+  public function setMimeType($mimeType)
+  {
+    $this->mimeType = $mimeType;
+  }
+  /**
+   * @return string
+   */
+  public function getMimeType()
+  {
+    return $this->mimeType;
+  }
+  /**
+   * @param string
+   */
+  public function setProductUrl($productUrl)
+  {
+    $this->productUrl = $productUrl;
+  }
+  /**
+   * @return string
+   */
+  public function getProductUrl()
+  {
+    return $this->productUrl;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(MediaItem::class, 'Google_Service_PhotosLibrary_MediaItem');

--- a/src/PhotosLibrary/MediaItemResult.php
+++ b/src/PhotosLibrary/MediaItemResult.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class MediaItemResult extends \Google\Model
+{
+  protected $mediaItemType = MediaItem::class;
+  protected $mediaItemDataType = '';
+  protected $statusType = Status::class;
+  protected $statusDataType = '';
+
+  /**
+   * @param MediaItem
+   */
+  public function setMediaItem(MediaItem $mediaItem)
+  {
+    $this->mediaItem = $mediaItem;
+  }
+  /**
+   * @return MediaItem
+   */
+  public function getMediaItem()
+  {
+    return $this->mediaItem;
+  }
+  /**
+   * @param Status
+   */
+  public function setStatus(Status $status)
+  {
+    $this->status = $status;
+  }
+  /**
+   * @return Status
+   */
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(MediaItemResult::class, 'Google_Service_PhotosLibrary_MediaItemResult');

--- a/src/PhotosLibrary/MediaMetadata.php
+++ b/src/PhotosLibrary/MediaMetadata.php
@@ -1,0 +1,112 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class MediaMetadata extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $creationTime;
+  /**
+   * @var string
+   */
+  public $height;
+  protected $photoType = Photo::class;
+  protected $photoDataType = '';
+  protected $videoType = Video::class;
+  protected $videoDataType = '';
+  /**
+   * @var string
+   */
+  public $width;
+
+  /**
+   * @param string
+   */
+  public function setCreationTime($creationTime)
+  {
+    $this->creationTime = $creationTime;
+  }
+  /**
+   * @return string
+   */
+  public function getCreationTime()
+  {
+    return $this->creationTime;
+  }
+  /**
+   * @param string
+   */
+  public function setHeight($height)
+  {
+    $this->height = $height;
+  }
+  /**
+   * @return string
+   */
+  public function getHeight()
+  {
+    return $this->height;
+  }
+  /**
+   * @param Photo
+   */
+  public function setPhoto(Photo $photo)
+  {
+    $this->photo = $photo;
+  }
+  /**
+   * @return Photo
+   */
+  public function getPhoto()
+  {
+    return $this->photo;
+  }
+  /**
+   * @param Video
+   */
+  public function setVideo(Video $video)
+  {
+    $this->video = $video;
+  }
+  /**
+   * @return Video
+   */
+  public function getVideo()
+  {
+    return $this->video;
+  }
+  /**
+   * @param string
+   */
+  public function setWidth($width)
+  {
+    $this->width = $width;
+  }
+  /**
+   * @return string
+   */
+  public function getWidth()
+  {
+    return $this->width;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(MediaMetadata::class, 'Google_Service_PhotosLibrary_MediaMetadata');

--- a/src/PhotosLibrary/MediaTypeFilter.php
+++ b/src/PhotosLibrary/MediaTypeFilter.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class MediaTypeFilter extends \Google\Collection
+{
+  protected $collection_key = 'mediaTypes';
+  /**
+   * @var string[]
+   */
+  public $mediaTypes;
+
+  /**
+   * @param string[]
+   */
+  public function setMediaTypes($mediaTypes)
+  {
+    $this->mediaTypes = $mediaTypes;
+  }
+  /**
+   * @return string[]
+   */
+  public function getMediaTypes()
+  {
+    return $this->mediaTypes;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(MediaTypeFilter::class, 'Google_Service_PhotosLibrary_MediaTypeFilter');

--- a/src/PhotosLibrary/NewEnrichmentItem.php
+++ b/src/PhotosLibrary/NewEnrichmentItem.php
@@ -1,0 +1,74 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class NewEnrichmentItem extends \Google\Model
+{
+  protected $locationEnrichmentType = LocationEnrichment::class;
+  protected $locationEnrichmentDataType = '';
+  protected $mapEnrichmentType = MapEnrichment::class;
+  protected $mapEnrichmentDataType = '';
+  protected $textEnrichmentType = TextEnrichment::class;
+  protected $textEnrichmentDataType = '';
+
+  /**
+   * @param LocationEnrichment
+   */
+  public function setLocationEnrichment(LocationEnrichment $locationEnrichment)
+  {
+    $this->locationEnrichment = $locationEnrichment;
+  }
+  /**
+   * @return LocationEnrichment
+   */
+  public function getLocationEnrichment()
+  {
+    return $this->locationEnrichment;
+  }
+  /**
+   * @param MapEnrichment
+   */
+  public function setMapEnrichment(MapEnrichment $mapEnrichment)
+  {
+    $this->mapEnrichment = $mapEnrichment;
+  }
+  /**
+   * @return MapEnrichment
+   */
+  public function getMapEnrichment()
+  {
+    return $this->mapEnrichment;
+  }
+  /**
+   * @param TextEnrichment
+   */
+  public function setTextEnrichment(TextEnrichment $textEnrichment)
+  {
+    $this->textEnrichment = $textEnrichment;
+  }
+  /**
+   * @return TextEnrichment
+   */
+  public function getTextEnrichment()
+  {
+    return $this->textEnrichment;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(NewEnrichmentItem::class, 'Google_Service_PhotosLibrary_NewEnrichmentItem');

--- a/src/PhotosLibrary/NewMediaItem.php
+++ b/src/PhotosLibrary/NewMediaItem.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class NewMediaItem extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $description;
+  protected $simpleMediaItemType = SimpleMediaItem::class;
+  protected $simpleMediaItemDataType = '';
+
+  /**
+   * @param string
+   */
+  public function setDescription($description)
+  {
+    $this->description = $description;
+  }
+  /**
+   * @return string
+   */
+  public function getDescription()
+  {
+    return $this->description;
+  }
+  /**
+   * @param SimpleMediaItem
+   */
+  public function setSimpleMediaItem(SimpleMediaItem $simpleMediaItem)
+  {
+    $this->simpleMediaItem = $simpleMediaItem;
+  }
+  /**
+   * @return SimpleMediaItem
+   */
+  public function getSimpleMediaItem()
+  {
+    return $this->simpleMediaItem;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(NewMediaItem::class, 'Google_Service_PhotosLibrary_NewMediaItem');

--- a/src/PhotosLibrary/NewMediaItemResult.php
+++ b/src/PhotosLibrary/NewMediaItemResult.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class NewMediaItemResult extends \Google\Model
+{
+  protected $mediaItemType = MediaItem::class;
+  protected $mediaItemDataType = '';
+  protected $statusType = Status::class;
+  protected $statusDataType = '';
+  /**
+   * @var string
+   */
+  public $uploadToken;
+
+  /**
+   * @param MediaItem
+   */
+  public function setMediaItem(MediaItem $mediaItem)
+  {
+    $this->mediaItem = $mediaItem;
+  }
+  /**
+   * @return MediaItem
+   */
+  public function getMediaItem()
+  {
+    return $this->mediaItem;
+  }
+  /**
+   * @param Status
+   */
+  public function setStatus(Status $status)
+  {
+    $this->status = $status;
+  }
+  /**
+   * @return Status
+   */
+  public function getStatus()
+  {
+    return $this->status;
+  }
+  /**
+   * @param string
+   */
+  public function setUploadToken($uploadToken)
+  {
+    $this->uploadToken = $uploadToken;
+  }
+  /**
+   * @return string
+   */
+  public function getUploadToken()
+  {
+    return $this->uploadToken;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(NewMediaItemResult::class, 'Google_Service_PhotosLibrary_NewMediaItemResult');

--- a/src/PhotosLibrary/Photo.php
+++ b/src/PhotosLibrary/Photo.php
@@ -1,0 +1,134 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class Photo extends \Google\Model
+{
+  /**
+   * @var float
+   */
+  public $apertureFNumber;
+  /**
+   * @var string
+   */
+  public $cameraMake;
+  /**
+   * @var string
+   */
+  public $cameraModel;
+  /**
+   * @var string
+   */
+  public $exposureTime;
+  /**
+   * @var float
+   */
+  public $focalLength;
+  /**
+   * @var int
+   */
+  public $isoEquivalent;
+
+  /**
+   * @param float
+   */
+  public function setApertureFNumber($apertureFNumber)
+  {
+    $this->apertureFNumber = $apertureFNumber;
+  }
+  /**
+   * @return float
+   */
+  public function getApertureFNumber()
+  {
+    return $this->apertureFNumber;
+  }
+  /**
+   * @param string
+   */
+  public function setCameraMake($cameraMake)
+  {
+    $this->cameraMake = $cameraMake;
+  }
+  /**
+   * @return string
+   */
+  public function getCameraMake()
+  {
+    return $this->cameraMake;
+  }
+  /**
+   * @param string
+   */
+  public function setCameraModel($cameraModel)
+  {
+    $this->cameraModel = $cameraModel;
+  }
+  /**
+   * @return string
+   */
+  public function getCameraModel()
+  {
+    return $this->cameraModel;
+  }
+  /**
+   * @param string
+   */
+  public function setExposureTime($exposureTime)
+  {
+    $this->exposureTime = $exposureTime;
+  }
+  /**
+   * @return string
+   */
+  public function getExposureTime()
+  {
+    return $this->exposureTime;
+  }
+  /**
+   * @param float
+   */
+  public function setFocalLength($focalLength)
+  {
+    $this->focalLength = $focalLength;
+  }
+  /**
+   * @return float
+   */
+  public function getFocalLength()
+  {
+    return $this->focalLength;
+  }
+  /**
+   * @param int
+   */
+  public function setIsoEquivalent($isoEquivalent)
+  {
+    $this->isoEquivalent = $isoEquivalent;
+  }
+  /**
+   * @return int
+   */
+  public function getIsoEquivalent()
+  {
+    return $this->isoEquivalent;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Photo::class, 'Google_Service_PhotosLibrary_Photo');

--- a/src/PhotosLibrary/Resource/Albums.php
+++ b/src/PhotosLibrary/Resource/Albums.php
@@ -1,0 +1,219 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary\Resource;
+
+use Google\Service\PhotosLibrary\AddEnrichmentToAlbumRequest;
+use Google\Service\PhotosLibrary\AddEnrichmentToAlbumResponse;
+use Google\Service\PhotosLibrary\Album;
+use Google\Service\PhotosLibrary\BatchAddMediaItemsToAlbumRequest;
+use Google\Service\PhotosLibrary\BatchAddMediaItemsToAlbumResponse;
+use Google\Service\PhotosLibrary\BatchRemoveMediaItemsFromAlbumRequest;
+use Google\Service\PhotosLibrary\BatchRemoveMediaItemsFromAlbumResponse;
+use Google\Service\PhotosLibrary\CreateAlbumRequest;
+use Google\Service\PhotosLibrary\ListAlbumsResponse;
+use Google\Service\PhotosLibrary\ShareAlbumRequest;
+use Google\Service\PhotosLibrary\ShareAlbumResponse;
+use Google\Service\PhotosLibrary\UnshareAlbumRequest;
+use Google\Service\PhotosLibrary\UnshareAlbumResponse;
+
+/**
+ * The "albums" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $photoslibraryService = new Google\Service\PhotosLibrary(...);
+ *   $albums = $photoslibraryService->albums;
+ *  </code>
+ */
+class Albums extends \Google\Service\Resource
+{
+  /**
+   * Adds an enrichment at a specified position in a defined album.
+   * (albums.addEnrichment)
+   *
+   * @param string $albumId Required. Identifier of the album where the enrichment
+   * is to be added.
+   * @param AddEnrichmentToAlbumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return AddEnrichmentToAlbumResponse
+   */
+  public function addEnrichment($albumId, AddEnrichmentToAlbumRequest $postBody, $optParams = [])
+  {
+    $params = ['albumId' => $albumId, 'postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('addEnrichment', [$params], AddEnrichmentToAlbumResponse::class);
+  }
+  /**
+   * Adds one or more media items in a user's Google Photos library to an album.
+   * The media items and albums must have been created by the developer via the
+   * API. Media items are added to the end of the album. If multiple media items
+   * are given, they are added in the order specified in this call. Each album can
+   * contain up to 20,000 media items. Only media items that are in the user's
+   * library can be added to an album. For albums that are shared, the album must
+   * either be owned by the user or the user must have joined the album as a
+   * collaborator. Partial success is not supported. The entire request will fail
+   * if an invalid media item or album is specified. (albums.batchAddMediaItems)
+   *
+   * @param string $albumId Required. Identifier of the Album that the media items
+   * are added to.
+   * @param BatchAddMediaItemsToAlbumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return BatchAddMediaItemsToAlbumResponse
+   */
+  public function batchAddMediaItems($albumId, BatchAddMediaItemsToAlbumRequest $postBody, $optParams = [])
+  {
+    $params = ['albumId' => $albumId, 'postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('batchAddMediaItems', [$params], BatchAddMediaItemsToAlbumResponse::class);
+  }
+  /**
+   * Removes one or more media items from a specified album. The media items and
+   * the album must have been created by the developer via the API. For albums
+   * that are shared, this action is only supported for media items that were
+   * added to the album by this user, or for all media items if the album was
+   * created by this user. Partial success is not supported. The entire request
+   * will fail and no action will be performed on the album if an invalid media
+   * item or album is specified. (albums.batchRemoveMediaItems)
+   *
+   * @param string $albumId Required. Identifier of the Album that the media items
+   * are to be removed from.
+   * @param BatchRemoveMediaItemsFromAlbumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return BatchRemoveMediaItemsFromAlbumResponse
+   */
+  public function batchRemoveMediaItems($albumId, BatchRemoveMediaItemsFromAlbumRequest $postBody, $optParams = [])
+  {
+    $params = ['albumId' => $albumId, 'postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('batchRemoveMediaItems', [$params], BatchRemoveMediaItemsFromAlbumResponse::class);
+  }
+  /**
+   * Creates an album in a user's Google Photos library. (albums.create)
+   *
+   * @param CreateAlbumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return Album
+   */
+  public function create(CreateAlbumRequest $postBody, $optParams = [])
+  {
+    $params = ['postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('create', [$params], Album::class);
+  }
+  /**
+   * Returns the album based on the specified `albumId`. The `albumId` must be the
+   * ID of an album owned by the user or a shared album that the user has joined.
+   * (albums.get)
+   *
+   * @param string $albumId Required. Identifier of the album to be requested.
+   * @param array $optParams Optional parameters.
+   * @return Album
+   */
+  public function get($albumId, $optParams = [])
+  {
+    $params = ['albumId' => $albumId];
+    $params = array_merge($params, $optParams);
+    return $this->call('get', [$params], Album::class);
+  }
+  /**
+   * Lists all albums shown to a user in the Albums tab of the Google Photos app.
+   * (albums.listAlbums)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool excludeNonAppCreatedData If set, the results exclude media
+   * items that were not created by this app. Defaults to false (all albums are
+   * returned). This field is ignored if the photoslibrary.readonly.appcreateddata
+   * scope is used.
+   * @opt_param int pageSize Maximum number of albums to return in the response.
+   * Fewer albums might be returned than the specified number. The default
+   * `pageSize` is 20, the maximum is 50.
+   * @opt_param string pageToken A continuation token to get the next page of the
+   * results. Adding this to the request returns the rows after the `pageToken`.
+   * The `pageToken` should be the value returned in the `nextPageToken` parameter
+   * in the response to the `listAlbums` request.
+   * @return ListAlbumsResponse
+   */
+  public function listAlbums($optParams = [])
+  {
+    $params = [];
+    $params = array_merge($params, $optParams);
+    return $this->call('list', [$params], ListAlbumsResponse::class);
+  }
+  /**
+   * Update the album with the specified `id`. Only the `id`, `title` and
+   * `cover_photo_media_item_id` fields of the album are read. The album must have
+   * been created by the developer via the API and must be owned by the user.
+   * (albums.patch)
+   *
+   * @param string $id Identifier for the album. This is a persistent identifier
+   * that can be used between sessions to identify this album.
+   * @param Album $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string updateMask Required. Indicate what fields in the provided
+   * album to update. The only valid values are `title` and
+   * `cover_photo_media_item_id`.
+   * @return Album
+   */
+  public function patch($id, Album $postBody, $optParams = [])
+  {
+    $params = ['id' => $id, 'postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', [$params], Album::class);
+  }
+  /**
+   * Marks an album as shared and accessible to other users. This action can only
+   * be performed on albums which were created by the developer via the API.
+   * (albums.share)
+   *
+   * @param string $albumId Required. Identifier of the album to be shared. This
+   * `albumId` must belong to an album created by the developer.
+   * @param ShareAlbumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return ShareAlbumResponse
+   */
+  public function share($albumId, ShareAlbumRequest $postBody, $optParams = [])
+  {
+    $params = ['albumId' => $albumId, 'postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('share', [$params], ShareAlbumResponse::class);
+  }
+  /**
+   * Marks a previously shared album as private. This means that the album is no
+   * longer shared and all the non-owners will lose access to the album. All non-
+   * owner content will be removed from the album. If a non-owner has previously
+   * added the album to their library, they will retain all photos in their
+   * library. This action can only be performed on albums which were created by
+   * the developer via the API. (albums.unshare)
+   *
+   * @param string $albumId Required. Identifier of the album to be unshared. This
+   * album id must belong to an album created by the developer.
+   * @param UnshareAlbumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return UnshareAlbumResponse
+   */
+  public function unshare($albumId, UnshareAlbumRequest $postBody, $optParams = [])
+  {
+    $params = ['albumId' => $albumId, 'postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('unshare', [$params], UnshareAlbumResponse::class);
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Albums::class, 'Google_Service_PhotosLibrary_Resource_Albums');

--- a/src/PhotosLibrary/Resource/MediaItems.php
+++ b/src/PhotosLibrary/Resource/MediaItems.php
@@ -1,0 +1,158 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary\Resource;
+
+use Google\Service\PhotosLibrary\BatchCreateMediaItemsRequest;
+use Google\Service\PhotosLibrary\BatchCreateMediaItemsResponse;
+use Google\Service\PhotosLibrary\BatchGetMediaItemsResponse;
+use Google\Service\PhotosLibrary\ListMediaItemsResponse;
+use Google\Service\PhotosLibrary\MediaItem;
+use Google\Service\PhotosLibrary\SearchMediaItemsRequest;
+use Google\Service\PhotosLibrary\SearchMediaItemsResponse;
+
+/**
+ * The "mediaItems" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $photoslibraryService = new Google\Service\PhotosLibrary(...);
+ *   $mediaItems = $photoslibraryService->mediaItems;
+ *  </code>
+ */
+class MediaItems extends \Google\Service\Resource
+{
+  /**
+   * Creates one or more media items in a user's Google Photos library. This is
+   * the second step for creating a media item. For details regarding Step 1,
+   * uploading the raw bytes to a Google Server, see Uploading media. This call
+   * adds the media item to the library. If an album `id` is specified, the call
+   * adds the media item to the album too. Each album can contain up to 20,000
+   * media items. By default, the media item will be added to the end of the
+   * library or album. If an album `id` and position are both defined, the media
+   * item is added to the album at the specified position. If the call contains
+   * multiple media items, they're added at the specified position. If you are
+   * creating a media item in a shared album where you are not the owner, you are
+   * not allowed to position the media item. Doing so will result in a `BAD
+   * REQUEST` error. (mediaItems.batchCreate)
+   *
+   * @param BatchCreateMediaItemsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return BatchCreateMediaItemsResponse
+   */
+  public function batchCreate(BatchCreateMediaItemsRequest $postBody, $optParams = [])
+  {
+    $params = ['postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('batchCreate', [$params], BatchCreateMediaItemsResponse::class);
+  }
+  /**
+   * Returns the list of media items for the specified media item identifiers.
+   * Items are returned in the same order as the supplied identifiers.
+   * (mediaItems.batchGet)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string mediaItemIds Required. Identifiers of the media items to be
+   * requested. Must not contain repeated identifiers and cannot be empty. The
+   * maximum number of media items that can be retrieved in one call is 50.
+   * @return BatchGetMediaItemsResponse
+   */
+  public function batchGet($optParams = [])
+  {
+    $params = [];
+    $params = array_merge($params, $optParams);
+    return $this->call('batchGet', [$params], BatchGetMediaItemsResponse::class);
+  }
+  /**
+   * Returns the media item for the specified media item identifier.
+   * (mediaItems.get)
+   *
+   * @param string $mediaItemId Required. Identifier of the media item to be
+   * requested.
+   * @param array $optParams Optional parameters.
+   * @return MediaItem
+   */
+  public function get($mediaItemId, $optParams = [])
+  {
+    $params = ['mediaItemId' => $mediaItemId];
+    $params = array_merge($params, $optParams);
+    return $this->call('get', [$params], MediaItem::class);
+  }
+  /**
+   * List all media items from a user's Google Photos library.
+   * (mediaItems.listMediaItems)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param int pageSize Maximum number of media items to return in the
+   * response. Fewer media items might be returned than the specified number. The
+   * default `pageSize` is 25, the maximum is 100.
+   * @opt_param string pageToken A continuation token to get the next page of the
+   * results. Adding this to the request returns the rows after the `pageToken`.
+   * The `pageToken` should be the value returned in the `nextPageToken` parameter
+   * in the response to the `listMediaItems` request.
+   * @return ListMediaItemsResponse
+   */
+  public function listMediaItems($optParams = [])
+  {
+    $params = [];
+    $params = array_merge($params, $optParams);
+    return $this->call('list', [$params], ListMediaItemsResponse::class);
+  }
+  /**
+   * Update the media item with the specified `id`. Only the `id` and
+   * `description` fields of the media item are read. The media item must have
+   * been created by the developer via the API and must be owned by the user.
+   * (mediaItems.patch)
+   *
+   * @param string $id Identifier for the media item. This is a persistent
+   * identifier that can be used between sessions to identify this media item.
+   * @param MediaItem $postBody
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param string updateMask Required. Indicate what fields in the provided
+   * media item to update. The only valid value is `description`.
+   * @return MediaItem
+   */
+  public function patch($id, MediaItem $postBody, $optParams = [])
+  {
+    $params = ['id' => $id, 'postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('patch', [$params], MediaItem::class);
+  }
+  /**
+   * Searches for media items in a user's Google Photos library. If no filters are
+   * set, then all media items in the user's library are returned. If an album is
+   * set, all media items in the specified album are returned. If filters are
+   * specified, media items that match the filters from the user's library are
+   * listed. If you set both the album and the filters, the request results in an
+   * error. (mediaItems.search)
+   *
+   * @param SearchMediaItemsRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return SearchMediaItemsResponse
+   */
+  public function search(SearchMediaItemsRequest $postBody, $optParams = [])
+  {
+    $params = ['postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('search', [$params], SearchMediaItemsResponse::class);
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(MediaItems::class, 'Google_Service_PhotosLibrary_Resource_MediaItems');

--- a/src/PhotosLibrary/Resource/SharedAlbums.php
+++ b/src/PhotosLibrary/Resource/SharedAlbums.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary\Resource;
+
+use Google\Service\PhotosLibrary\Album;
+use Google\Service\PhotosLibrary\JoinSharedAlbumRequest;
+use Google\Service\PhotosLibrary\JoinSharedAlbumResponse;
+use Google\Service\PhotosLibrary\LeaveSharedAlbumRequest;
+use Google\Service\PhotosLibrary\LeaveSharedAlbumResponse;
+use Google\Service\PhotosLibrary\ListSharedAlbumsResponse;
+
+/**
+ * The "sharedAlbums" collection of methods.
+ * Typical usage is:
+ *  <code>
+ *   $photoslibraryService = new Google\Service\PhotosLibrary(...);
+ *   $sharedAlbums = $photoslibraryService->sharedAlbums;
+ *  </code>
+ */
+class SharedAlbums extends \Google\Service\Resource
+{
+  /**
+   * Returns the album based on the specified `shareToken`. (sharedAlbums.get)
+   *
+   * @param string $shareToken Required. Share token of the album to be requested.
+   * @param array $optParams Optional parameters.
+   * @return Album
+   */
+  public function get($shareToken, $optParams = [])
+  {
+    $params = ['shareToken' => $shareToken];
+    $params = array_merge($params, $optParams);
+    return $this->call('get', [$params], Album::class);
+  }
+  /**
+   * Joins a shared album on behalf of the Google Photos user. (sharedAlbums.join)
+   *
+   * @param JoinSharedAlbumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return JoinSharedAlbumResponse
+   */
+  public function join(JoinSharedAlbumRequest $postBody, $optParams = [])
+  {
+    $params = ['postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('join', [$params], JoinSharedAlbumResponse::class);
+  }
+  /**
+   * Leaves a previously-joined shared album on behalf of the Google Photos user.
+   * The user must not own this album. (sharedAlbums.leave)
+   *
+   * @param LeaveSharedAlbumRequest $postBody
+   * @param array $optParams Optional parameters.
+   * @return LeaveSharedAlbumResponse
+   */
+  public function leave(LeaveSharedAlbumRequest $postBody, $optParams = [])
+  {
+    $params = ['postBody' => $postBody];
+    $params = array_merge($params, $optParams);
+    return $this->call('leave', [$params], LeaveSharedAlbumResponse::class);
+  }
+  /**
+   * Lists all shared albums available in the Sharing tab of the user's Google
+   * Photos app. (sharedAlbums.listSharedAlbums)
+   *
+   * @param array $optParams Optional parameters.
+   *
+   * @opt_param bool excludeNonAppCreatedData If set, the results exclude media
+   * items that were not created by this app. Defaults to false (all albums are
+   * returned). This field is ignored if the photoslibrary.readonly.appcreateddata
+   * scope is used.
+   * @opt_param int pageSize Maximum number of albums to return in the response.
+   * Fewer albums might be returned than the specified number. The default
+   * `pageSize` is 20, the maximum is 50.
+   * @opt_param string pageToken A continuation token to get the next page of the
+   * results. Adding this to the request returns the rows after the `pageToken`.
+   * The `pageToken` should be the value returned in the `nextPageToken` parameter
+   * in the response to the `listSharedAlbums` request.
+   * @return ListSharedAlbumsResponse
+   */
+  public function listSharedAlbums($optParams = [])
+  {
+    $params = [];
+    $params = array_merge($params, $optParams);
+    return $this->call('list', [$params], ListSharedAlbumsResponse::class);
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(SharedAlbums::class, 'Google_Service_PhotosLibrary_Resource_SharedAlbums');

--- a/src/PhotosLibrary/SearchMediaItemsRequest.php
+++ b/src/PhotosLibrary/SearchMediaItemsRequest.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class SearchMediaItemsRequest extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $albumId;
+  protected $filtersType = Filters::class;
+  protected $filtersDataType = '';
+  /**
+   * @var string
+   */
+  public $orderBy;
+  /**
+   * @var int
+   */
+  public $pageSize;
+  /**
+   * @var string
+   */
+  public $pageToken;
+
+  /**
+   * @param string
+   */
+  public function setAlbumId($albumId)
+  {
+    $this->albumId = $albumId;
+  }
+  /**
+   * @return string
+   */
+  public function getAlbumId()
+  {
+    return $this->albumId;
+  }
+  /**
+   * @param Filters
+   */
+  public function setFilters(Filters $filters)
+  {
+    $this->filters = $filters;
+  }
+  /**
+   * @return Filters
+   */
+  public function getFilters()
+  {
+    return $this->filters;
+  }
+  /**
+   * @param string
+   */
+  public function setOrderBy($orderBy)
+  {
+    $this->orderBy = $orderBy;
+  }
+  /**
+   * @return string
+   */
+  public function getOrderBy()
+  {
+    return $this->orderBy;
+  }
+  /**
+   * @param int
+   */
+  public function setPageSize($pageSize)
+  {
+    $this->pageSize = $pageSize;
+  }
+  /**
+   * @return int
+   */
+  public function getPageSize()
+  {
+    return $this->pageSize;
+  }
+  /**
+   * @param string
+   */
+  public function setPageToken($pageToken)
+  {
+    $this->pageToken = $pageToken;
+  }
+  /**
+   * @return string
+   */
+  public function getPageToken()
+  {
+    return $this->pageToken;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(SearchMediaItemsRequest::class, 'Google_Service_PhotosLibrary_SearchMediaItemsRequest');

--- a/src/PhotosLibrary/SearchMediaItemsResponse.php
+++ b/src/PhotosLibrary/SearchMediaItemsResponse.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class SearchMediaItemsResponse extends \Google\Collection
+{
+  protected $collection_key = 'mediaItems';
+  protected $mediaItemsType = MediaItem::class;
+  protected $mediaItemsDataType = 'array';
+  /**
+   * @var string
+   */
+  public $nextPageToken;
+
+  /**
+   * @param MediaItem[]
+   */
+  public function setMediaItems($mediaItems)
+  {
+    $this->mediaItems = $mediaItems;
+  }
+  /**
+   * @return MediaItem[]
+   */
+  public function getMediaItems()
+  {
+    return $this->mediaItems;
+  }
+  /**
+   * @param string
+   */
+  public function setNextPageToken($nextPageToken)
+  {
+    $this->nextPageToken = $nextPageToken;
+  }
+  /**
+   * @return string
+   */
+  public function getNextPageToken()
+  {
+    return $this->nextPageToken;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(SearchMediaItemsResponse::class, 'Google_Service_PhotosLibrary_SearchMediaItemsResponse');

--- a/src/PhotosLibrary/ShareAlbumRequest.php
+++ b/src/PhotosLibrary/ShareAlbumRequest.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class ShareAlbumRequest extends \Google\Model
+{
+  protected $sharedAlbumOptionsType = SharedAlbumOptions::class;
+  protected $sharedAlbumOptionsDataType = '';
+
+  /**
+   * @param SharedAlbumOptions
+   */
+  public function setSharedAlbumOptions(SharedAlbumOptions $sharedAlbumOptions)
+  {
+    $this->sharedAlbumOptions = $sharedAlbumOptions;
+  }
+  /**
+   * @return SharedAlbumOptions
+   */
+  public function getSharedAlbumOptions()
+  {
+    return $this->sharedAlbumOptions;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ShareAlbumRequest::class, 'Google_Service_PhotosLibrary_ShareAlbumRequest');

--- a/src/PhotosLibrary/ShareAlbumResponse.php
+++ b/src/PhotosLibrary/ShareAlbumResponse.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class ShareAlbumResponse extends \Google\Model
+{
+  protected $shareInfoType = ShareInfo::class;
+  protected $shareInfoDataType = '';
+
+  /**
+   * @param ShareInfo
+   */
+  public function setShareInfo(ShareInfo $shareInfo)
+  {
+    $this->shareInfo = $shareInfo;
+  }
+  /**
+   * @return ShareInfo
+   */
+  public function getShareInfo()
+  {
+    return $this->shareInfo;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ShareAlbumResponse::class, 'Google_Service_PhotosLibrary_ShareAlbumResponse');

--- a/src/PhotosLibrary/ShareInfo.php
+++ b/src/PhotosLibrary/ShareInfo.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class ShareInfo extends \Google\Model
+{
+  /**
+   * @var bool
+   */
+  public $isJoinable;
+  /**
+   * @var bool
+   */
+  public $isJoined;
+  /**
+   * @var bool
+   */
+  public $isOwned;
+  /**
+   * @var string
+   */
+  public $shareToken;
+  /**
+   * @var string
+   */
+  public $shareableUrl;
+  protected $sharedAlbumOptionsType = SharedAlbumOptions::class;
+  protected $sharedAlbumOptionsDataType = '';
+
+  /**
+   * @param bool
+   */
+  public function setIsJoinable($isJoinable)
+  {
+    $this->isJoinable = $isJoinable;
+  }
+  /**
+   * @return bool
+   */
+  public function getIsJoinable()
+  {
+    return $this->isJoinable;
+  }
+  /**
+   * @param bool
+   */
+  public function setIsJoined($isJoined)
+  {
+    $this->isJoined = $isJoined;
+  }
+  /**
+   * @return bool
+   */
+  public function getIsJoined()
+  {
+    return $this->isJoined;
+  }
+  /**
+   * @param bool
+   */
+  public function setIsOwned($isOwned)
+  {
+    $this->isOwned = $isOwned;
+  }
+  /**
+   * @return bool
+   */
+  public function getIsOwned()
+  {
+    return $this->isOwned;
+  }
+  /**
+   * @param string
+   */
+  public function setShareToken($shareToken)
+  {
+    $this->shareToken = $shareToken;
+  }
+  /**
+   * @return string
+   */
+  public function getShareToken()
+  {
+    return $this->shareToken;
+  }
+  /**
+   * @param string
+   */
+  public function setShareableUrl($shareableUrl)
+  {
+    $this->shareableUrl = $shareableUrl;
+  }
+  /**
+   * @return string
+   */
+  public function getShareableUrl()
+  {
+    return $this->shareableUrl;
+  }
+  /**
+   * @param SharedAlbumOptions
+   */
+  public function setSharedAlbumOptions(SharedAlbumOptions $sharedAlbumOptions)
+  {
+    $this->sharedAlbumOptions = $sharedAlbumOptions;
+  }
+  /**
+   * @return SharedAlbumOptions
+   */
+  public function getSharedAlbumOptions()
+  {
+    return $this->sharedAlbumOptions;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(ShareInfo::class, 'Google_Service_PhotosLibrary_ShareInfo');

--- a/src/PhotosLibrary/SharedAlbumOptions.php
+++ b/src/PhotosLibrary/SharedAlbumOptions.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class SharedAlbumOptions extends \Google\Model
+{
+  /**
+   * @var bool
+   */
+  public $isCollaborative;
+  /**
+   * @var bool
+   */
+  public $isCommentable;
+
+  /**
+   * @param bool
+   */
+  public function setIsCollaborative($isCollaborative)
+  {
+    $this->isCollaborative = $isCollaborative;
+  }
+  /**
+   * @return bool
+   */
+  public function getIsCollaborative()
+  {
+    return $this->isCollaborative;
+  }
+  /**
+   * @param bool
+   */
+  public function setIsCommentable($isCommentable)
+  {
+    $this->isCommentable = $isCommentable;
+  }
+  /**
+   * @return bool
+   */
+  public function getIsCommentable()
+  {
+    return $this->isCommentable;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(SharedAlbumOptions::class, 'Google_Service_PhotosLibrary_SharedAlbumOptions');

--- a/src/PhotosLibrary/SimpleMediaItem.php
+++ b/src/PhotosLibrary/SimpleMediaItem.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class SimpleMediaItem extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $fileName;
+  /**
+   * @var string
+   */
+  public $uploadToken;
+
+  /**
+   * @param string
+   */
+  public function setFileName($fileName)
+  {
+    $this->fileName = $fileName;
+  }
+  /**
+   * @return string
+   */
+  public function getFileName()
+  {
+    return $this->fileName;
+  }
+  /**
+   * @param string
+   */
+  public function setUploadToken($uploadToken)
+  {
+    $this->uploadToken = $uploadToken;
+  }
+  /**
+   * @return string
+   */
+  public function getUploadToken()
+  {
+    return $this->uploadToken;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(SimpleMediaItem::class, 'Google_Service_PhotosLibrary_SimpleMediaItem');

--- a/src/PhotosLibrary/Status.php
+++ b/src/PhotosLibrary/Status.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class Status extends \Google\Collection
+{
+  protected $collection_key = 'details';
+  /**
+   * @var int
+   */
+  public $code;
+  /**
+   * @var array[]
+   */
+  public $details;
+  /**
+   * @var string
+   */
+  public $message;
+
+  /**
+   * @param int
+   */
+  public function setCode($code)
+  {
+    $this->code = $code;
+  }
+  /**
+   * @return int
+   */
+  public function getCode()
+  {
+    return $this->code;
+  }
+  /**
+   * @param array[]
+   */
+  public function setDetails($details)
+  {
+    $this->details = $details;
+  }
+  /**
+   * @return array[]
+   */
+  public function getDetails()
+  {
+    return $this->details;
+  }
+  /**
+   * @param string
+   */
+  public function setMessage($message)
+  {
+    $this->message = $message;
+  }
+  /**
+   * @return string
+   */
+  public function getMessage()
+  {
+    return $this->message;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Status::class, 'Google_Service_PhotosLibrary_Status');

--- a/src/PhotosLibrary/TextEnrichment.php
+++ b/src/PhotosLibrary/TextEnrichment.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class TextEnrichment extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $text;
+
+  /**
+   * @param string
+   */
+  public function setText($text)
+  {
+    $this->text = $text;
+  }
+  /**
+   * @return string
+   */
+  public function getText()
+  {
+    return $this->text;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(TextEnrichment::class, 'Google_Service_PhotosLibrary_TextEnrichment');

--- a/src/PhotosLibrary/UnshareAlbumRequest.php
+++ b/src/PhotosLibrary/UnshareAlbumRequest.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class UnshareAlbumRequest extends \Google\Model
+{
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(UnshareAlbumRequest::class, 'Google_Service_PhotosLibrary_UnshareAlbumRequest');

--- a/src/PhotosLibrary/UnshareAlbumResponse.php
+++ b/src/PhotosLibrary/UnshareAlbumResponse.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class UnshareAlbumResponse extends \Google\Model
+{
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(UnshareAlbumResponse::class, 'Google_Service_PhotosLibrary_UnshareAlbumResponse');

--- a/src/PhotosLibrary/Video.php
+++ b/src/PhotosLibrary/Video.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace Google\Service\PhotosLibrary;
+
+class Video extends \Google\Model
+{
+  /**
+   * @var string
+   */
+  public $cameraMake;
+  /**
+   * @var string
+   */
+  public $cameraModel;
+  public $fps;
+  /**
+   * @var string
+   */
+  public $status;
+
+  /**
+   * @param string
+   */
+  public function setCameraMake($cameraMake)
+  {
+    $this->cameraMake = $cameraMake;
+  }
+  /**
+   * @return string
+   */
+  public function getCameraMake()
+  {
+    return $this->cameraMake;
+  }
+  /**
+   * @param string
+   */
+  public function setCameraModel($cameraModel)
+  {
+    $this->cameraModel = $cameraModel;
+  }
+  /**
+   * @return string
+   */
+  public function getCameraModel()
+  {
+    return $this->cameraModel;
+  }
+  public function setFps($fps)
+  {
+    $this->fps = $fps;
+  }
+  public function getFps()
+  {
+    return $this->fps;
+  }
+  /**
+   * @param string
+   */
+  public function setStatus($status)
+  {
+    $this->status = $status;
+  }
+  /**
+   * @return string
+   */
+  public function getStatus()
+  {
+    return $this->status;
+  }
+}
+
+// Adding a class alias for backwards compatibility with the previous class name.
+class_alias(Video::class, 'Google_Service_PhotosLibrary_Video');


### PR DESCRIPTION
These service classes were no longer made available since the v0.200
release.

@see https://github.com/googleapis/google-api-php-client-services/issues/557

Regenerated per guidance in that ticket.

This is regenerated from photoslibrary:v1 `https://photoslibrary.googleapis.com/$discovery/rest?version=v1`